### PR TITLE
Feature: Preserve "recognized" JVM args

### DIFF
--- a/src/main/groovy/com/palantir/launchconfig/EclipseLaunchConfigTask.groovy
+++ b/src/main/groovy/com/palantir/launchconfig/EclipseLaunchConfigTask.groovy
@@ -71,7 +71,7 @@ class EclipseLaunchConfigTask extends DefaultTask {
 
             stringAttribute(
                     key: "org.eclipse.jdt.launching.VM_ARGUMENTS",
-                    value: javaExec.allJvmArgs.join(" "))
+                    value: buildVmParams(javaExec).join(" "))
 
             stringAttribute(
                     key: "org.eclipse.jdt.launching.PROJECT_ATTR",
@@ -87,6 +87,21 @@ class EclipseLaunchConfigTask extends DefaultTask {
         Path launchFile = Paths.get("${project.projectDir}/${project.name}-${javaExec.name}.launch")
         String xmlString = writer.toString() + "\n"
         Files.write(launchFile, xmlString.getBytes("UTF-8")).toFile()
+    }
+
+    /**
+     * Build the VM Params from the JVM Args and the System Properties.
+     *
+     * Note: this needs to be left as "protected" to avoid scoping issues above
+     */
+    protected List<String> buildVmParams(JavaExec javaExec) {
+        List<String> vmParams = new ArrayList<String>()
+        vmParams.addAll(javaExec.jvmArgs)
+        javaExec.systemProperties.each() { k, v -> vmParams.add("-D${k}${v ? '=' + v : ''}") }
+        if (javaExec.enableAssertions) vmParams.add("-ea")
+        if (javaExec.minHeapSize != null) vmParams.add("-Xms${javaExec.minHeapSize}")
+        if (javaExec.maxHeapSize != null) vmParams.add("-Xmx${javaExec.maxHeapSize}")
+        return vmParams
     }
 
     boolean shouldGenerate(String taskName) {

--- a/src/main/groovy/com/palantir/launchconfig/IdeaLaunchConfigTask.groovy
+++ b/src/main/groovy/com/palantir/launchconfig/IdeaLaunchConfigTask.groovy
@@ -90,6 +90,9 @@ class IdeaLaunchConfigTask extends DefaultTask {
         List<String> vmParams = new ArrayList<String>()
         vmParams.addAll(javaExec.jvmArgs)
         javaExec.systemProperties.each() { k, v -> vmParams.add("-D${k}${v ? '=' + v : ''}") }
+        if (javaExec.enableAssertions) vmParams.add("-ea")
+        if (javaExec.minHeapSize != null) vmParams.add("-Xms${javaExec.minHeapSize}")
+        if (javaExec.maxHeapSize != null) vmParams.add("-Xmx${javaExec.maxHeapSize}")
         return vmParams
     }
 

--- a/src/test/groovy/com/palantir/launchconfig/EclipseLaunchConfigTaskIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/launchconfig/EclipseLaunchConfigTaskIntegrationSpec.groovy
@@ -48,6 +48,7 @@ class EclipseLaunchConfigTaskIntegrationSpec extends IntegrationSpec {
                 args('server', 'dev/conf/server.yml')
                 jvmArgs('-server', '-client', '-Ddw.assets')
                 workingDir '/'
+                maxHeapSize '4g'
                 systemProperties['dw.abc'] = 123
             }
         """.stripIndent()
@@ -80,6 +81,10 @@ class EclipseLaunchConfigTaskIntegrationSpec extends IntegrationSpec {
 
         xml.stringAttribute.any {
             it.@key == "org.eclipse.jdt.launching.VM_ARGUMENTS" && it.@value.toString().indexOf("-Ddw.abc=123") > -1
+        }
+
+        xml.stringAttribute.any {
+            it.@key == "org.eclipse.jdt.launching.VM_ARGUMENTS" && it.@value.toString().indexOf("-Xmx4g") > -1
         }
 
         xml.stringAttribute.any {

--- a/src/test/groovy/com/palantir/launchconfig/EclipseLaunchConfigTaskIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/launchconfig/EclipseLaunchConfigTaskIntegrationSpec.groovy
@@ -48,6 +48,7 @@ class EclipseLaunchConfigTaskIntegrationSpec extends IntegrationSpec {
                 args('server', 'dev/conf/server.yml')
                 jvmArgs('-server', '-client', '-Ddw.assets')
                 workingDir '/'
+                systemProperties['dw.abc'] = 123
             }
         """.stripIndent()
 
@@ -75,6 +76,10 @@ class EclipseLaunchConfigTaskIntegrationSpec extends IntegrationSpec {
 
         xml.stringAttribute.any {
             it.@key == "org.eclipse.jdt.launching.VM_ARGUMENTS" && it.@value.toString().indexOf("-Ddw.assets") > -1
+        }
+
+        xml.stringAttribute.any {
+            it.@key == "org.eclipse.jdt.launching.VM_ARGUMENTS" && it.@value.toString().indexOf("-Ddw.abc=123") > -1
         }
 
         xml.stringAttribute.any {
@@ -346,5 +351,41 @@ class EclipseLaunchConfigTaskIntegrationSpec extends IntegrationSpec {
 
         !fileExists("${projectName}-runDev.launch")
         !fileExists("${projectName}-otherRun.launch")
+    }
+
+    def "generates launch files including 'recognized' values"() {
+        setup:
+        writeHelloWorld("com.testing")
+        String main = "com.testing.HelloWorld"
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'eclipse'
+            apply plugin: 'com.palantir.launch-config'
+
+            task runDev(type: JavaExec) {
+                classpath project.sourceSets.main.runtimeClasspath
+                main '${main}'
+                jvmArgs('-server', '-client', '-ea', '-Xmx4g', '-Xms2g')
+            }
+        """.stripIndent()
+
+        when:
+        ExecutionResult result = runTasksSuccessfully("eclipse")
+
+        then:
+        result.success
+
+        String launchFilename = "${projectName}-runDev.launch"
+        fileExists(launchFilename)
+
+        def xml = new XmlSlurper().parseText(file(launchFilename).text)
+
+        xml.stringAttribute.any {
+            it.@key == "org.eclipse.jdt.launching.MAIN_TYPE" && it.@value == main
+        }
+
+        xml.stringAttribute.any {
+            it.@key == "org.eclipse.jdt.launching.VM_ARGUMENTS" && it.@value.toString().indexOf("-server -client -ea -Xms2g -Xmx4g") > -1
+        }
     }
 }

--- a/src/test/groovy/com/palantir/launchconfig/IdeaLaunchConfigTaskIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/launchconfig/IdeaLaunchConfigTaskIntegrationSpec.groovy
@@ -48,6 +48,7 @@ class IdeaLaunchConfigTaskIntegrationSpec extends IntegrationSpec {
                 args('server', 'dev/conf/server.yml')
                 jvmArgs('-server', '-client')
                 workingDir '/'
+                maxHeapSize '4g'
                 systemProperties['dw.assets'] = null
                 systemProperties['dw.abc'] = 123
             }
@@ -74,6 +75,7 @@ class IdeaLaunchConfigTaskIntegrationSpec extends IntegrationSpec {
         runConfig.option.any { it.@name == "VM_PARAMETERS" && it.@value.toString().contains("-Ddw.assets") }
         runConfig.option.any { it.@name == "VM_PARAMETERS" && it.@value.toString().contains("-Ddw.abc=123") }
         runConfig.option.any { it.@name == "VM_PARAMETERS" && !it.@value.toString().contains("com.palantir.launchconfig") }
+        runConfig.option.any { it.@name == "VM_PARAMETERS" && it.@value.toString().contains("-Xmx4g") }
         runConfig.option.any { it.@name == "PROGRAM_PARAMETERS" && it.@value == "server dev/conf/server.yml" }
         runConfig.option.any { it.@name == "WORKING_DIRECTORY" && it.@value == "/" }
         runConfig.module.any { it.@name == this.projectName }

--- a/src/test/groovy/com/palantir/launchconfig/IdeaLaunchConfigTaskIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/launchconfig/IdeaLaunchConfigTaskIntegrationSpec.groovy
@@ -342,4 +342,41 @@ class IdeaLaunchConfigTaskIntegrationSpec extends IntegrationSpec {
         runManager.configuration.any { it.@name == "${subprojectIdeaModelName}-runDev" }
         runManager.configuration.any { it.@name == "${subprojectIdeaModelName}-otherRun" }
     }
+
+    def "generates launch files including 'recognized' values"() {
+        setup:
+        writeHelloWorld("com.testing")
+        String main = "com.testing.HelloWorld"
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'idea'
+            apply plugin: 'com.palantir.launch-config'
+
+            task runDev(type: JavaExec) {
+                classpath project.sourceSets.main.runtimeClasspath
+                main '${main}'
+                jvmArgs('-server', '-client', '-ea', '-Xmx4g', '-Xms2g')
+            }
+        """.stripIndent()
+
+        when:
+        ExecutionResult result = runTasksSuccessfully("idea")
+
+        then:
+        result.success
+
+        String launchFilename = "${projectName}.iws"
+        fileExists(launchFilename)
+
+        def xml = new XmlSlurper().parseText(file(launchFilename).text)
+        def runManager = xml.component.findResult { it.@name == "RunManager" ? it : null }
+        runManager != null
+
+        def runConfig = runManager.configuration.findResult { it.@name == "${projectName}-runDev" ? it : null }
+        runConfig != null
+
+        runConfig.option.any { it.@name == "MAIN_CLASS_NAME" && it.@value == main }
+        runConfig.option.any { it.@name == "VM_PARAMETERS" && it.@value.toString().contains("-server -client -ea -Xms2g -Xmx4g") }
+        runConfig.module.any { it.@name == this.projectName }
+    }
 }


### PR DESCRIPTION
Fixes an issue where `jvmArgs` settings like `-Xmx4g` are dropped from the generated launch configs. This is caused by the settings being "recognized". Relevant Gradle [code](https://github.com/gradle/gradle/blob/master/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java#L167).

TLDR, it matches settings and parses them into the `JavaExec` object.
```java
            } else if (argStr.startsWith(XMS_PREFIX)) {
                minHeapSize = argStr.substring(XMS_PREFIX.length());
            } else if (argStr.startsWith(XMX_PREFIX)) {
                maxHeapSize = argStr.substring(XMX_PREFIX.length());
            } else if (argStr.startsWith(BOOTCLASSPATH_PREFIX)) {
```

This happens in the following `JavaExec` configurations:

```gradle
task runDev(type: JavaExec) {
    classpath project.sourceSets.main.runtimeClasspath
    main '${main}'
    jvmArgs('-server', '-client', '-ea', '-Xmx4g', '-Xms2g')
}
```
OR
```gradle
task runDev(type: JavaExec) {
    classpath project.sourceSets.main.runtimeClasspath
    main '${main}'
    maxHeapSize '4g'
}
```

Both of these will produce a vm arguments section without the `-Xmx4g`.

